### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In order to follow this you will need to install the latest version of: [git](ht
 Open a terminal/console and type these commands
 
 ```
-git clone git@github.com:elevenyellow/coinfy.git
+git clone https://github.com/elevenyellow/coinfy.git
 cd coinfy
 npm install
 npm run build


### PR DESCRIPTION
fixing error in cloning as reported in README

```bash
git clone git@github.com:elevenyellow/coinfy.git
Cloning into 'coinfy'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

cloning via https doesn't require authorization